### PR TITLE
feat(cli): add tmops doctor and interactive bdd-scaffold wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # TeamOps (tmops) – Multi‑Instance AI Orchestration
 
+TeamOps by Anthony Calek (@happycode)
+
+[![npm version](https://img.shields.io/npm/v/%40happycode%2Ftmops)](https://www.npmjs.com/package/@happycode/tmops)
+
 Lightweight, test‑driven orchestration for multiple AI code agent instances using checkpoints and Markdown instructions.
 
 <div align="center">
@@ -87,6 +91,21 @@ Examples
 - OpenAI CLI (non‑interactive by default; use a wrapper if needed)
   ```bash
   export AGENT_CMD="openai"
+  ```
+
+## Install via npm (optional)
+
+- Try the 5‑minute demo (no setup):
+  ```bash
+  npx @happycode/tmops demo-gherkin
+  ```
+- Or add as a dev dependency:
+  ```bash
+  npm i -D @happycode/tmops
+  # Initialize a feature (interactive)
+  tmops init --interactive
+  # Extract features from a curated doc
+  tmops bdd-scaffold --from docs/product/gherkin/acceptance_demo.md --stack js --gen-steps
   ```
 
 ### Setup & Usage

--- a/tmops_v6_portable/package.json
+++ b/tmops_v6_portable/package.json
@@ -1,8 +1,26 @@
 {
-  "name": "tmops-cli",
-  "version": "0.0.1",
-  "description": "TeamOps portable CLI: init, multi-run, and BDD/Gherkin scaffolding",
+  "name": "@happycode/tmops",
+  "version": "0.1.0",
+  "description": "TeamOps CLI by Anthony Calek (@happycode): init, multi-run, and BDD/Gherkin scaffolding",
   "license": "MIT",
+  "author": "Anthony Calek (@happycode)",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/happycode-ch/tmops_framework.git"
+  },
+  "homepage": "https://github.com/happycode-ch/tmops_framework#readme",
+  "bugs": {
+    "url": "https://github.com/happycode-ch/tmops_framework/issues"
+  },
+  "keywords": [
+    "tmops",
+    "teamops",
+    "bdd",
+    "gherkin",
+    "cli",
+    "orchestration",
+    "tdd"
+  ],
   "bin": {
     "tmops": "bin/tmops.js"
   },
@@ -21,4 +39,3 @@
     "templates/"
   ]
 }
-


### PR DESCRIPTION
## 📋 Summary

- Adds `tmops doctor` command for environment validation and troubleshooting
- Adds interactive wizard mode for `bdd-scaffold` to improve beginner experience
- Prepares npm package `@happycode/tmops` for publication (v0.1.0)
- Updates README with npm installation instructions and badge

## 🎯 What's Included

### New Command: `tmops doctor`
**Purpose**: Validate development environment and diagnose issues

**Checks performed**:
- ✅ Node.js version (>= 16)
- ✅ Bash availability
- ✅ Git installation
- ✅ Git repository presence
- ✅ Write access to project directory
- ✅ Script executables (init, scaffold, run_manager)
- ⚠️ Advisory check for `@cucumber/cucumber`

**Output**: PASS/FAIL with actionable fix notes; exits non-zero only for critical failures

**Usage**:
```bash
tmops doctor
```

### Interactive Wizard: `bdd-scaffold --interactive`
**Purpose**: Guide beginners through BDD feature extraction without CLI expertise

**Features**:
- 🔍 Auto-discovers curated docs under `docs/product/gherkin/`
- 📝 Interactive prompts for:
  - Source document selection (or manual path entry)
  - Stack choice (js/python)
  - Feature slug (with smart suggestions)
  - Output directory (with defaults)
  - Step stub generation (optional)
- ⚠️ Counts gherkin blocks and warns if none found
- 🚀 Offers to run tests with exact command or automatic execution

**Usage**:
```bash
tmops bdd-scaffold --interactive
```

### NPM Package Preparation
- Package name: `@happycode/tmops`
- Version: `0.1.0`
- Updated `package.json` with complete metadata
- Added npm badge to README
- Installation instructions in README

## 🔧 Technical Changes

### Files Modified
- **[tmops_v6_portable/bin/tmops.js](tmops_v6_portable/bin/tmops.js)**: +257 lines
  - Added `doctor` command with comprehensive checks
  - Added interactive wizard for `bdd-scaffold`
  - Improved CLI help text and error handling
  
- **[tmops_v6_portable/package.json](tmops_v6_portable/package.json)**: Enhanced metadata
  - Added repository, bugs, homepage fields
  - Updated keywords for npm discoverability
  - Set version to 0.1.0
  
- **[README.md](README.md)**: +19 lines
  - Added npm installation section
  - Added npm badge
  - Updated quick start with npm option

## ✅ Benefits

### For Beginners
- **Zero-config validation**: `tmops doctor` catches environment issues early
- **Guided workflow**: Interactive wizard eliminates need to memorize flags
- **Clear error messages**: Actionable fixes instead of cryptic errors
- **NPM installation**: Simple `npm install -g @happycode/tmops` instead of manual setup

### For Advanced Users
- **Non-interactive mode**: All existing flags still work
- **Scriptable**: `tmops doctor` can be used in CI/CD pipelines
- **Backward compatible**: No breaking changes to existing workflows

## 🧪 Test Plan

### Manual Testing
- [x] `tmops doctor` on clean environment (all checks pass)
- [x] `tmops doctor` with missing dependencies (shows appropriate errors)
- [x] `tmops bdd-scaffold --interactive` with existing docs
- [x] `tmops bdd-scaffold --interactive` with no docs (graceful handling)
- [x] Interactive wizard workflow end-to-end (from doc selection to test run)
- [x] All existing non-interactive flags still work

### Environment Validation
```bash
# Test doctor command
tmops doctor

# Test interactive wizard
tmops bdd-scaffold --interactive

# Test non-interactive mode (backward compatibility)
tmops bdd-scaffold --from docs/product/gherkin/example.md --stack js
```

## 📦 NPM Publication Readiness

### Package Details
- **Name**: `@happycode/tmops`
- **Version**: `0.1.0`
- **Scope**: `@happycode` (organization)
- **License**: MIT (verify before publishing)
- **Main executable**: `bin/tmops.js`

### Pre-publication Checklist
- [x] Package.json metadata complete
- [x] CLI commands tested
- [x] README updated with npm installation
- [x] Version set to 0.1.0
- [ ] Verify npm organization access
- [ ] Run `npm pack` to test package creation
- [ ] Test installation from tarball locally
- [ ] Publish to npm with `npm publish --access public`

## 🚀 Next Steps (Post-Merge)

1. **Test local package**:
   ```bash
   cd tmops_v6_portable
   npm pack
   npm install -g ./happycode-tmops-0.1.0.tgz
   tmops doctor
   ```

2. **Publish to npm**:
   ```bash
   npm login  # Ensure logged in to @happycode org
   npm publish --access public
   ```

3. **Update README** (if needed):
   - Add installation badge
   - Link to npm package page
   - Add changelog entry for v0.1.0

4. **Test global installation**:
   ```bash
   npm install -g @happycode/tmops
   tmops doctor
   tmops bdd-scaffold --interactive
   ```

## 🔒 Security/Privacy

- No network calls except during npm installation
- All file operations are local and user-controlled
- Interactive prompts validate user input
- No credential storage or transmission

## 📖 Documentation Updates

- README now includes npm installation option
- CLI help text updated for new commands
- Interactive wizard provides inline help and examples

## 🏷️ Labels

- `enhancement`
- `cli`
- `npm`
- `beginner-friendly`
- `dx` (developer experience)

🤖 Generated with [Claude Code](https://claude.com/claude-code)