### PR TITLE
feat(types, bdd, cli, ci): Types-first workflow, Gherkin scaffolding, tmops CLI, and publish-on-tag

### DIFF
--- a/.gherkin-lintrc
+++ b/.gherkin-lintrc
@@ -1,9 +1,7 @@
 {
-  "no-empty-file": "error",
-  "no-unnamed-features": "error",
-  "no-unnamed-scenarios": "error",
-  "no-dupe-scenario-names": "error",
-  "no-trailing-spaces": "warn",
-  "name-length": ["off", {"min": 3, "max": 120}]
+  "no-empty-file": "on",
+  "no-unnamed-features": "on",
+  "no-unnamed-scenarios": "on",
+  "no-dupe-scenario-names": "on",
+  "no-trailing-spaces": "on"
 }
-

--- a/.notes/internal-summaries/TODO.md
+++ b/.notes/internal-summaries/TODO.md
@@ -1,0 +1,39 @@
+# TeamOps To‑Do (Q4 2025)
+
+Owner: Anthony Calek (@happycode)  
+Scope: tmops framework, CLI, docs, packaging
+
+## Release & Packaging
+- [ ] Publish npm package `@happycode/tmops` v0.1.0
+- [ ] Add GitHub Release notes + tag `v0.1.0`
+- [ ] Add CI job: publish to npm on tag push (manual approve)
+- [ ] Validate `npx @happycode/tmops demo-gherkin` on macOS/Linux/Windows (Git Bash)
+
+## CLI & UX
+- [ ] `tmops init --interactive`: add optional prompts for run‑type, feature name validation
+- [ ] `tmops bdd-scaffold --interactive`: remember last answers (simple JSON cache)
+- [ ] `tmops doctor`: detect Windows Shell and surface Git Bash guidance; add Python toolchain advisory
+- [ ] Add `tmops --version` and `tmops --help` grouped examples
+
+## BDD / Gherkin Flow
+- [ ] Optional gherkin lint (style checks; advisory only)
+- [ ] Step stub templates per stack (js/python) with example matchers
+- [ ] Simple sample data fixtures under `tests/data/` for demo
+
+## Docs & Onboarding
+- [ ] README: add short video/GIF of 5‑minute demo
+- [ ] docs/product/gherkin/README: add “good scenario” vs “imperative anti‑pattern” examples
+- [ ] instance_instructions: cross‑link Gherkin Author → Tester → Implementer hand‑off
+
+## Cross‑Platform & Portability
+- [ ] Reduce bash dependency (Node port of `bdd_scaffold.sh`)
+- [ ] Windows quickstart notes (Git Bash, path tips)
+
+## Repo Hygiene
+- [ ] Add CODEOWNERS and issue templates
+- [ ] Add CONTRIBUTING.md (link to AGENTS.md + style guides)
+- [ ] Periodically roll `.archive/*` entries by date
+
+Notes
+- Keep curated acceptance doc as source of truth; re‑extract features on change.
+- Preserve docs subfolders per feature: `internal`, `external`, `archive`, `images`.

--- a/tmops_v6_portable/instance_instructions/01_orchestrator.md
+++ b/tmops_v6_portable/instance_instructions/01_orchestrator.md
@@ -43,8 +43,9 @@ You are the ORCHESTRATOR instance coordinating 3 other instances.
 2. WAIT for human: "[BEGIN]: Start orchestration for <feature>"
 3. Initialize logging to .tmops/<feature>/runs/initial/logs/orchestrator.log
 4. Read Task Spec from .tmops/<feature>/runs/initial/TASK_SPEC.md
-5. Create .tmops/<feature>/runs/initial/checkpoints/001-discovery-trigger.md
-6. Report: "[ORCHESTRATOR] READY: Tester (and optional Gherkin Author) can begin. Trigger 001 created."
+5. OPTIONAL: If using Types Curator, WAIT for "[CONFIRMED]: 000-types-draft.md ready" and note `docs/types/types.json`.
+6. Create .tmops/<feature>/runs/initial/checkpoints/001-discovery-trigger.md
+7. Report: "[ORCHESTRATOR] READY: Tester (and optional Gherkin Author) can begin. Trigger 001 created."
 7. OPTIONAL: If a Gherkin Author is used, WAIT for "[CONFIRMED]: 002-acceptance-draft.md ready" and note the curated doc path (docs/product/gherkin/...).
 8. WAIT for human: "[CONFIRMED]: Tester has completed"
 9. Create .tmops/<feature>/runs/initial/checkpoints/004-impl-trigger.md

--- a/tmops_v6_portable/tmops_tools/bdd_scaffold.sh
+++ b/tmops_v6_portable/tmops_tools/bdd_scaffold.sh
@@ -94,8 +94,8 @@ while IFS= read -r line; do
     current=""
     continue
   fi
-  # accumulate block contents
-  current+="$line\n"
+  # accumulate block contents with real newlines
+  current+="$line"$'\n'
 done < "$tmpfile.blocks"
 
 if [[ ${#created[@]} -eq 0 ]]; then

--- a/tmops_v6_portable/tmops_tools/bdd_scaffold.sh
+++ b/tmops_v6_portable/tmops_tools/bdd_scaffold.sh
@@ -99,7 +99,7 @@ while IFS= read -r line; do
 done < "$tmpfile.blocks"
 
 if [[ ${#created[@]} -eq 0 ]]; then
-  echo "WARNING: No ```gherkin blocks found in $INPUT" >&2
+  echo "WARNING: No \`\`\`gherkin blocks found in $INPUT" >&2
   exit 0
 fi
 
@@ -155,4 +155,3 @@ if [[ "$STACK" == "js" ]]; then
 elif [[ "$STACK" == "python" ]]; then
   echo "Run: pytest -q"
 fi
-


### PR DESCRIPTION
## 📋 Summary

- Adds optional Types-First → Tests → Impl workflow (Types Curator role + blueprint).
- Enhances BDD onboarding (Gherkin Author docs, scaffold tool, CI lint + dry-run).
- Introduces tmops CLI (npm-ready) with interactive commands and doctor checks.
- Adds lightweight CI (doctor, types smoke, BDD lint/dry-run) and a publish-on-tag workflow gated by manual approval.
- Refactors README to be model-agnostic, beginner-friendly, and npm-aware.

## 🎯 Why

- Make TeamOps approachable for beginners while powerful for advanced users.
- Support repeatable, contract-driven development (types first) and living documentation (Gherkin).
- Provide an installable CLI for consistent UX across projects.
- Safely automate CI and releases with approvals.

## 🔧 Scope of Changes

### Types-first (optional)
- New role and blueprint: [tmops_v6_portable/instance_instructions/02b_types_curator.md:1](tmops_v6_portable/instance_instructions/02b_types_curator.md#L1), [tmops_v6_portable/templates/13_types_interview_blueprint.md:1](tmops_v6_portable/templates/13_types_interview_blueprint.md#L1)
- CLI: `tmops types-init`, `tmops types-materialize`, `tmops types-gate`, `tmops demo-types-first` (see [tmops_v6_portable/bin/tmops.js:1](tmops_v6_portable/bin/tmops.js#L1))
- Orchestrator mentions optional 000-types-draft.md (see [tmops_v6_portable/instance_instructions/01_orchestrator.md:1](tmops_v6_portable/instance_instructions/01_orchestrator.md#L1))

### BDD workflow
- Gherkin Author role already included (beginner Quickstart + tag taxonomy): [tmops_v6_portable/instance_instructions/02a_gherkin_author.md:1](tmops_v6_portable/instance_instructions/02a_gherkin_author.md#L1)
- Blueprint: [tmops_v6_portable/templates/12_bdd_interview_blueprint.md:1](tmops_v6_portable/templates/12_bdd_interview_blueprint.md#L1)
- Scaffold tool: [tmops_v6_portable/tmops_tools/bdd_scaffold.sh:1](tmops_v6_portable/tmops_tools/bdd_scaffold.sh#L1) (extracts ```gherkin blocks → .feature)
- Gherkin docs (product-level): [docs/product/gherkin/README.md:1](docs/product/gherkin/README.md#L1)

### CLI (npm-ready)
- Package metadata (scoped): [tmops_v6_portable/package.json:1](tmops_v6_portable/package.json#L1) (name @happycode/tmops, bin tmops)
- Entry: [tmops_v6_portable/bin/tmops.js:1](tmops_v6_portable/bin/tmops.js#L1)
- Commands: init (interactive), run-manager, demo-gherkin, bdd-scaffold (interactive), doctor, plus types-first commands

### CI and Publish
- CI pipeline: [.github/workflows/ci.yml:1](.github/workflows/ci.yml#L1) (doctor, types-first smoke, BDD scaffold + gherkin-lint + cucumber dry-run)
- Publish on tag with manual approval: [.github/workflows/publish.yml:1](.github/workflows/publish.yml#L1)
- Gherkin lint config: [.gherkin-lintrc:1](.gherkin-lintrc#L1)

### README
- Model-agnostic Quick Start (AGENT_CMD), Choose Your Agent, npm install usage, CI Quickstart, Publish steps.
- Types-First Workflow (why, artifacts, commands, gates).
- Visible TeamOps logo by default (no dropdown).

## 🧪 How To Test (Local)

### Doctor/env check:
```bash
node tmops_v6_portable/bin/tmops.js doctor
```

### 5-minute BDD demo:
```bash
node tmops_v6_portable/bin/tmops.js demo-gherkin
node tmops_v6_portable/bin/tmops.js bdd-scaffold --interactive
# Optional parse check:
npx @cucumber/cucumber cucumber-js tests/features --dry-run
```

### 5-minute Types-first demo:
```bash
node tmops_v6_portable/bin/tmops.js demo-types-first
# Inspect generated: docs/types/types.json, src/types/…, tests/types/…
```

## 🚀 CI Behavior

### ci.yml:
- **Doctor**: runs `tmops doctor`
- **Types smoke**: runs `demo-types-first` and verifies artifacts exist
- **BDD smoke**: creates curated doc, scaffolds features, lints with `gherkin-lint`, and runs `cucumber-js --dry-run`

### publish.yml:
- Triggers on tags `v*`
- Requires manual approval (issue-based)
- Publishes `@happycode/tmops` (validates package.json version == tag)

## 📦 Release (NPM)

- Ensure repo secret `NPM_TOKEN` exists.
- Tag: `git tag v0.1.0 && git push --tags`
- Approve the publish workflow when prompted.
- Verify: `npx @happycode/tmops demo-gherkin` in a clean repo.

## ↔️ Backward Compatibility

- Defaults unchanged (init still creates/checks out feature/<name> unless flags used).
- No network calls or npm publish occur without tag + approval.
- BDD lint/dry-run does not require app code.

## ⚠️ Risks & Mitigations

- **GitHub Actions**: low risk; read-only smoke tests. If noisy, disable workflows temporarily.
- **NPM publish**: gated by tag + manual approval + token; can remove NPM_TOKEN to hard stop.

## ☑️ Checklist

- [x] Beginner-friendly docs and demos
- [x] CLI interactive flows (init, scaffold)
- [x] Types Curator role + blueprint
- [x] Gherkin Author docs + scaffold tool
- [x] CI (doctor, lint, dry-run) green
- [x] Publish workflow added with manual approval
- [x] README updated (model-agnostic, npm, CI)
- [x] Gherkin lint config present

## 📎 File References

- [README.md:1](README.md#L1)
- [tmops_v6_portable/bin/tmops.js:1](tmops_v6_portable/bin/tmops.js#L1)
- [tmops_v6_portable/package.json:1](tmops_v6_portable/package.json#L1)
- [tmops_v6_portable/tmops_tools/bdd_scaffold.sh:1](tmops_v6_portable/tmops_tools/bdd_scaffold.sh#L1)
- [tmops_v6_portable/instance_instructions/02a_gherkin_author.md:1](tmops_v6_portable/instance_instructions/02a_gherkin_author.md#L1)
- [tmops_v6_portable/instance_instructions/02b_types_curator.md:1](tmops_v6_portable/instance_instructions/02b_types_curator.md#L1)
- [tmops_v6_portable/templates/12_bdd_interview_blueprint.md:1](tmops_v6_portable/templates/12_bdd_interview_blueprint.md#L1)
- [tmops_v6_portable/templates/13_types_interview_blueprint.md:1](tmops_v6_portable/templates/13_types_interview_blueprint.md#L1)
- [tmops_v6_portable/instance_instructions/01_orchestrator.md:1](tmops_v6_portable/instance_instructions/01_orchestrator.md#L1)
- [docs/product/gherkin/README.md:1](docs/product/gherkin/README.md#L1)
- [.github/workflows/ci.yml:1](.github/workflows/ci.yml#L1)
- [.github/workflows/publish.yml:1](.github/workflows/publish.yml#L1)
- [.gherkin-lintrc:1](.gherkin-lintrc#L1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)